### PR TITLE
Ajout blacklist / whitelist des startups

### DIFF
--- a/app/components/standup-deck.js
+++ b/app/components/standup-deck.js
@@ -162,10 +162,10 @@ export default Ember.Component.extend(EKMixin, {
       return startup.get('status') === 'success' && BLACKLIST.indexOf(startup.get('id')) < 0;
     });
   }),
-  shuffledIncubateurStartups: Ember.computed('incubateurStartups', function() {
-    return this.shuffle(this.get('incubateurStartups'));
+  combinedStartups: Ember.computed.union('incubateurStartups', 'friendsStartups'),
+  startups: Ember.computed('combinedStartups', function() {
+    return this.shuffle(this.get('combinedStartups'));
   }),
-  startups: Ember.computed.union('shuffledIncubateurStartups', 'friendsStartups'),
   currentStartup: Ember.computed('startups', 'startupIndex', function() {
     return this.get('startups')[this.get('startupIndex')];
   }),

--- a/app/components/standup-deck.js
+++ b/app/components/standup-deck.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import { EKMixin, keyUp } from 'ember-keyboard';
 
+const BLACKLIST = ['urbaclic', 'retraite', 'ogptoolbox', 'api-geo'];
+
 export default Ember.Component.extend(EKMixin, {
   // Slide (60) + buffer (5)
   STARTUP_SLIDE_DURATION: 65,
@@ -155,7 +157,11 @@ export default Ember.Component.extend(EKMixin, {
   incubateurStartups: Ember.computed('activeStartups', function() {
     return this.get('activeStartups').rejectBy('status', 'success')
   }),
-  friendsStartups: Ember.computed.filterBy('activeStartups', 'status', 'success'),
+  friendsStartups: Ember.computed('activeStartups', function() {
+    return this.get('activeStartups').filter(function(startup) {
+      return startup.get('status') === 'success' && BLACKLIST.indexOf(startup.get('id')) < 0;
+    });
+  }),
   shuffledIncubateurStartups: Ember.computed('incubateurStartups', function() {
     return this.shuffle(this.get('incubateurStartups'));
   }),

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -2,6 +2,13 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   model() {
-    return this.get('store').findAll('startup');
+    this.get('store').createRecord('startup', {
+      id: 'openfisca',
+      name: 'OpenFisca',
+      pitch: 'Rendre le droit calculable',
+      status: 'success'
+    });
+
+    return this.get('store').findAll('startup', { reload: true });
   }
 });


### PR DESCRIPTION
Suite à la discussion sur #22, on garde la liste originale mais on enlèves des produits dont on ne parle plus:
 - urbaclic
 - retraite
 - ogptoolbox
 - api-geo

Et on rajoute les startups dont on parle:
 - openfisca

En plus, on mélange tout ensemble au lieu de faire les "friends" à la fin.