### PR TITLE
Supprime le passage automatique à la startup suivante

### DIFF
--- a/app/components/standup-deck.js
+++ b/app/components/standup-deck.js
@@ -108,11 +108,6 @@ export default Ember.Component.extend(EKMixin, {
 
     if (Date.parse(new Date()) >= endTime) {
       this.get('hifi').play('assets/sounds/gong.mp3');
-      if (state === 'startups') {
-        this.send('nextStartup');
-      } else {
-        this.send('goHome');
-      }
     }
   },
 


### PR DESCRIPTION
Pour arrêter de voler du temps à la personne d'après, la pression sociale suffit. (+le gong sonne sans arrêt).